### PR TITLE
fix version check with warning message output

### DIFF
--- a/ipset.go
+++ b/ipset.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"regexp"
 )
 
 // Version of current package
@@ -218,11 +219,14 @@ func isSupported() (bool, error) {
 }
 
 func getMajorVersion(version []byte) int {
-	vIndex := bytes.IndexByte(version, 'v')
-	dotIndex := bytes.IndexByte(version, '.')
+	vVer := regexp.MustCompile(" v\\d+(\\.\\d+)+").Find(version)
+	if vVer == nil {
+		return 0
+	}
+	dotIndex := bytes.IndexByte(vVer, '.')
 	var majorVersion int
-	for i := vIndex + 1; i < dotIndex; i++ {
-		if c := version[i]; c >= '0' && c <= '9' {
+	for i := 2; i < dotIndex; i++ {
+		if c := vVer[i]; c >= '0' && c <= '9' {
 			majorVersion = majorVersion*10 + int(c-'0')
 		} else {
 			return 0

--- a/ipset_test.go
+++ b/ipset_test.go
@@ -62,6 +62,7 @@ func Test_GetMajorVersion(t *testing.T) {
 		{[]byte("ipset v6.29, protocol version: 6"), 6},
 		{[]byte("ipset v7.1, protocol version: 7"), 7},
 		{[]byte("ipset v10.0, protocol version: 10"), 10},
+		{[]byte("Warning: Kernel support protocol versions 6-6 while userspace supports protocol versions 6-7\nipset v7.1, protocol version: 7"), 7},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
ipset version check will getting wrong result if userspace support more protocol versions than Kernel

e.g.
the code `execCommand(ipsetPath, _version).CombinedOutput()` get output string:
Warning: Kernel support protocol versions 6-6 while userspace supports protocol versions 6-7
ipset v7.1, protocol version: 7

getMajorVersion() will return 0 and isSupported() get false


use regex to getting correct version string instead of simply looking for the character 'v'.
